### PR TITLE
Create Capacitor teleprompter app

### DIFF
--- a/teleprompter-app/README.md
+++ b/teleprompter-app/README.md
@@ -1,0 +1,48 @@
+# Teleprompter Capacitor App
+
+This project packages the browser-based teleprompter into a Capacitor application for iOS devices.
+
+## Setup
+
+```bash
+cd teleprompter-app
+npm install
+```
+
+## Development
+
+Start a local server to view the app in a browser:
+
+```bash
+npm start
+```
+
+There is no build step for this simple app but the script is kept for future needs:
+
+```bash
+npm run build
+```
+
+## iOS
+
+Add the iOS platform and open the project in Xcode:
+
+```bash
+npx cap sync ios
+npm run ios
+```
+
+### Testing on Real Hardware
+
+1. Connect your iPhone or iPad with a USB cable.
+2. In Xcode, select your device in the target dropdown.
+3. Press the **Run** button to install and launch the app on the device.
+4. Ensure camera and microphone permissions are accepted when prompted.
+
+## Service Worker
+
+A basic `service-worker.js` is included so the project can later be expanded to a Progressive Web App.
+
+## Permissions
+
+Camera, microphone and photo library permissions are automatically added to the iOS `Info.plist` via `capacitor.config.ts`.

--- a/teleprompter-app/capacitor.config.ts
+++ b/teleprompter-app/capacitor.config.ts
@@ -1,0 +1,17 @@
+import { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'com.mycompany.teleprompter',
+  appName: 'Teleprompter',
+  webDir: 'public',
+  bundledWebRuntime: false,
+  ios: {
+    plist: {
+      NSCameraUsageDescription: 'Camera access is required for recording video',
+      NSMicrophoneUsageDescription: 'Microphone access is required for recording audio',
+      NSPhotoLibraryAddUsageDescription: 'Photo library access is required to save recordings'
+    }
+  }
+};
+
+export default config;

--- a/teleprompter-app/package.json
+++ b/teleprompter-app/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "teleprompter-app",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "npx http-server ./public -o",
+    "build": "echo 'No build step required'",
+    "ios": "npx cap open ios"
+  },
+  "dependencies": {
+    "@capacitor/cli": "^6.0.0",
+    "@capacitor/core": "^6.0.0",
+    "@capacitor/ios": "^6.0.0",
+    "http-server": "^14.1.1"
+  }
+}

--- a/teleprompter-app/public/index.html
+++ b/teleprompter-app/public/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="style.css">
+  <title>Teleprompter</title>
+</head>
+<body>
+  <div id="container">
+    <video id="cameraPreview" autoplay muted playsinline></video>
+    <div id="controls">
+      <textarea id="scriptInput">This is your teleprompter script. Start speaking...</textarea>
+      <div class="button-row">
+        <button id="startScroll">Start</button>
+        <button id="stopScroll">Stop</button>
+        <label>Speed: <input type="range" id="speedControl" min="1" max="10" value="3"></label>
+        <label>Text Size: <input type="range" id="textSize" min="1" max="4" step="0.1" value="2"></label>
+        <button id="flipH" class="toggle-btn">Flip H</button>
+        <button id="flipV" class="toggle-btn">Flip V</button>
+      </div>
+      <div class="button-row">
+        <button id="startAudioRec">🎙️ Record Audio</button>
+        <button id="startVideoRec">🎥 Record Video</button>
+        <button id="stopRec">⏹ Stop Recording</button>
+      </div>
+      <div class="button-row">
+        <button id="toggleCamera">Toggle Camera</button>
+        <label>Video Source: <select id="videoSelect"></select></label>
+        <label>Audio Source: <select id="audioSelect"></select></label>
+      </div>
+    </div>
+    <div id="recordingIndicator" class="hidden">
+      <span id="recDot"></span>
+      <span id="recType">● Recording</span>
+    </div>
+
+    <div id="teleprompter">
+      <div id="scrollContent"></div>
+    </div>
+    <div id="recordingList">
+      <h4>Recordings:</h4>
+      <ul id="recordings"></ul>
+    </div>
+  </div>
+  <script src="script.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('service-worker.js');
+      });
+    }
+  </script>
+</body>
+</html>

--- a/teleprompter-app/public/script.js
+++ b/teleprompter-app/public/script.js
@@ -1,0 +1,197 @@
+const scriptInput = document.getElementById("scriptInput");
+const scrollContent = document.getElementById("scrollContent");
+const teleprompter = document.getElementById("teleprompter");
+
+const startBtn = document.getElementById("startScroll");
+const stopBtn = document.getElementById("stopScroll");
+const speedControl = document.getElementById("speedControl");
+const textSizeSlider = document.getElementById("textSize");
+
+const flipHBtn = document.getElementById("flipH");
+const flipVBtn = document.getElementById("flipV");
+
+const startAudioRecBtn = document.getElementById("startAudioRec");
+const startVideoRecBtn = document.getElementById("startVideoRec");
+const stopRecBtn = document.getElementById("stopRec");
+const recordingsList = document.getElementById("recordings");
+
+const recIndicator = document.getElementById("recordingIndicator");
+const recTypeLabel = document.getElementById("recType");
+
+const toggleCameraBtn = document.getElementById("toggleCamera");
+const videoSelect = document.getElementById("videoSelect");
+const audioSelect = document.getElementById("audioSelect");
+
+let scrollInterval = null;
+let mediaRecorder;
+let recordedChunks = [];
+let activeStream = null;
+
+let currentFacing = "user";
+let currentVideoDevice = null;
+let currentAudioDevice = null;
+
+let takeCounts = {
+  audio: 0,
+  video: 0
+};
+
+scrollContent.textContent = scriptInput.value;
+
+scriptInput.addEventListener("input", () => {
+  scrollContent.textContent = scriptInput.value;
+});
+
+textSizeSlider.addEventListener("input", () => {
+  scrollContent.style.fontSize = `${textSizeSlider.value}em`;
+});
+
+startBtn.addEventListener("click", () => {
+  if (scrollInterval) clearInterval(scrollInterval);
+  scrollInterval = setInterval(() => {
+    teleprompter.scrollBy(0, parseInt(speedControl.value));
+  }, 50);
+});
+
+stopBtn.addEventListener("click", () => {
+  if (scrollInterval) clearInterval(scrollInterval);
+});
+
+flipHBtn.addEventListener("click", () => {
+  scrollContent.classList.toggle("flipped-h");
+  flipHBtn.classList.toggle("active");
+});
+
+flipVBtn.addEventListener("click", () => {
+  scrollContent.classList.toggle("flipped-v");
+  flipVBtn.classList.toggle("active");
+});
+
+function getDatePrefix() {
+  const now = new Date();
+  return now.toISOString().slice(0, 10);
+}
+
+function getNextTake(type) {
+  takeCounts[type]++;
+  return `${getDatePrefix()}_Take-${takeCounts[type]}_${type}.webm`;
+}
+
+function addToDownloadList(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const li = document.createElement("li");
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.textContent = `Download ${filename}`;
+  li.appendChild(a);
+  recordingsList.appendChild(li);
+}
+
+function buildConstraints(withVideo) {
+  const constraints = {};
+  if (withVideo) {
+    constraints.video = currentVideoDevice
+      ? { deviceId: { exact: currentVideoDevice } }
+      : { facingMode: currentFacing };
+  }
+  constraints.audio = currentAudioDevice
+    ? { deviceId: { exact: currentAudioDevice } }
+    : true;
+  return constraints;
+}
+
+async function startCameraPreview() {
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia(buildConstraints(true));
+    document.getElementById("cameraPreview").srcObject = stream;
+    activeStream?.getTracks().forEach(t => t.stop());
+    activeStream = stream;
+    return stream;
+  } catch (err) {
+    console.error("Camera access denied:", err);
+  }
+}
+
+async function populateDevices() {
+  const devices = await navigator.mediaDevices.enumerateDevices();
+  videoSelect.innerHTML = "";
+  audioSelect.innerHTML = "";
+  devices.forEach(device => {
+    const option = document.createElement("option");
+    option.value = device.deviceId;
+    option.text = device.label || device.deviceId;
+    if (device.kind === "videoinput") {
+      videoSelect.appendChild(option);
+      if (device.deviceId === currentVideoDevice) option.selected = true;
+    } else if (device.kind === "audioinput") {
+      audioSelect.appendChild(option);
+      if (device.deviceId === currentAudioDevice) option.selected = true;
+    }
+  });
+}
+
+async function startRecording(video = false) {
+  if (mediaRecorder && mediaRecorder.state !== "inactive") {
+    mediaRecorder.stop();
+  }
+
+  activeStream?.getTracks().forEach(track => track.stop());
+
+  activeStream = await navigator.mediaDevices.getUserMedia(buildConstraints(video));
+
+  recordedChunks = [];
+  mediaRecorder = new MediaRecorder(activeStream);
+
+  mediaRecorder.ondataavailable = e => recordedChunks.push(e.data);
+
+  mediaRecorder.onstop = () => {
+    const blob = new Blob(recordedChunks, { type: "video/webm" });
+    const type = video ? "video" : "audio";
+    const filename = getNextTake(type);
+    addToDownloadList(blob, filename);
+
+    recIndicator.classList.add("hidden");
+    startVideoRecBtn.classList.remove("recording");
+    startAudioRecBtn.classList.remove("recording");
+  };
+
+  mediaRecorder.start();
+
+  recIndicator.classList.remove("hidden");
+  recTypeLabel.textContent = video ? "🎥 Recording" : "🎙️ Recording";
+  if (video) {
+    startVideoRecBtn.classList.add("recording");
+  } else {
+    startAudioRecBtn.classList.add("recording");
+  }
+}
+
+startAudioRecBtn.addEventListener("click", () => startRecording(false));
+startVideoRecBtn.addEventListener("click", () => startRecording(true));
+
+stopRecBtn.addEventListener("click", () => {
+  if (mediaRecorder && mediaRecorder.state !== "inactive") {
+    mediaRecorder.stop();
+  }
+});
+
+toggleCameraBtn.addEventListener("click", async () => {
+  currentFacing = currentFacing === "user" ? "environment" : "user";
+  currentVideoDevice = null;
+  await startCameraPreview();
+});
+
+videoSelect.addEventListener("change", async () => {
+  currentVideoDevice = videoSelect.value;
+  await startCameraPreview();
+});
+
+audioSelect.addEventListener("change", async () => {
+  currentAudioDevice = audioSelect.value;
+  await startCameraPreview();
+});
+
+navigator.mediaDevices.addEventListener("devicechange", populateDevices);
+
+startCameraPreview().then(populateDevices);

--- a/teleprompter-app/public/service-worker.js
+++ b/teleprompter-app/public/service-worker.js
@@ -1,0 +1,19 @@
+const CACHE_NAME = 'teleprompter-cache-v1';
+const urlsToCache = [
+  '/',
+  '/index.html',
+  '/style.css',
+  '/script.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});

--- a/teleprompter-app/public/style.css
+++ b/teleprompter-app/public/style.css
@@ -1,0 +1,168 @@
+body, html {
+  margin: 0;
+  padding: 0;
+  background: black;
+  color: white;
+  font-family: sans-serif;
+  height: 100%;
+  overflow: hidden;
+}
+
+#container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+#cameraPreview {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 160px;
+  height: 120px;
+  border: 2px solid white;
+  z-index: 10;
+  background: black;
+  object-fit: cover;
+}
+
+#controls {
+  background: #111;
+  padding: 10px;
+  z-index: 5;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.4);
+}
+
+#controls textarea {
+  width: 100%;
+  height: 100px;
+  margin-bottom: 10px;
+  font-size: 1.2em;
+  background: #222;
+  color: white;
+  border: 1px solid #444;
+  padding: 8px;
+  resize: vertical;
+  border-radius: 4px;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+button {
+  background: #333;
+  color: white;
+  border: 1px solid #555;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 1em;
+  cursor: pointer;
+  transition: background 0.2s, border 0.2s;
+}
+
+button:hover {
+  background: #444;
+  border-color: #777;
+}
+
+button.toggle-btn.active {
+  background: #0066cc;
+  border-color: #3399ff;
+}
+
+label {
+  font-size: 0.9em;
+  color: #ccc;
+}
+
+input[type=range] {
+  vertical-align: middle;
+}
+
+/* Flip transforms */
+.flipped-h {
+  transform: scaleX(-1);
+}
+
+.flipped-v {
+  transform: scaleY(-1);
+}
+
+#teleprompter {
+  flex-grow: 1;
+  overflow-y: scroll;
+  padding: 40px;
+  background: black;
+  transition: transform 0.3s ease;
+}
+
+#scrollContent {
+  white-space: pre-wrap;
+  font-size: 2em;
+  line-height: 1.6em;
+}
+
+#recordingList {
+  background: #111;
+  padding: 10px;
+  border-top: 1px solid #333;
+  font-size: 0.9em;
+  color: #ccc;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+#recordingList ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+#recordingList li {
+  margin: 4px 0;
+  border-bottom: 1px solid #222;
+  padding-bottom: 4px;
+}
+
+#recordingIndicator {
+  position: absolute;
+  top: 140px;
+  right: 10px;
+  background: rgba(0, 0, 0, 0.7);
+  padding: 6px 10px;
+  border-radius: 20px;
+  font-size: 0.9em;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: white;
+  z-index: 20;
+}
+
+#recDot {
+  width: 10px;
+  height: 10px;
+  background: red;
+  border-radius: 50%;
+  animation: pulse 1s infinite;
+}
+
+@keyframes pulse {
+  0% { opacity: 1; }
+  50% { opacity: 0.3; }
+  100% { opacity: 1; }
+}
+
+button.recording {
+  background: #a00 !important;
+  border-color: #d33 !important;
+  color: white !important;
+}
+
+.hidden {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- add web teleprompter under `teleprompter-app`
- configure Capacitor project and iOS plist permissions
- implement dual camera toggle and external device selectors
- include a basic service worker and README instructions

## Testing
- `npm run build` *(fails: Unknown env config http-proxy)*
- `npm start` *(fails: 403 Forbidden - GET https://registry.npmjs.org/http-server)*
- `npx cap init Teleprompter com.mycompany.teleprompter --web-dir=public --npm-client npm` *(failed: 403 Forbidden)*
- `npx cap add ios` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688791f2b808832081bd78e619d8e0a9